### PR TITLE
UX improvements to "edit signatures" form:

### DIFF
--- a/CRM/Signatures/Form/Signatures.php
+++ b/CRM/Signatures/Form/Signatures.php
@@ -53,7 +53,8 @@ class CRM_Signatures_Form_Signatures extends CRM_Core_Form {
     $this->add(
       'textarea',
       'signature_email_plain',
-      E::ts('E-mail signature (plain text)', array('domain' => 'de.systopia.signatures'))
+      E::ts('E-mail signature (plain text)', array('domain' => 'de.systopia.signatures')),
+      ['rows' => '10']
     );
     $this->add(
       'wysiwyg',
@@ -63,7 +64,8 @@ class CRM_Signatures_Form_Signatures extends CRM_Core_Form {
     $this->add(
       'textarea',
       'signature_mass_mailing_plain',
-      E::ts('Mass mailing signature (plain text)', array('domain' => 'de.systopia.signatures'))
+      E::ts('Mass mailing signature (plain text)', array('domain' => 'de.systopia.signatures')),
+      ['rows' => '10']
     );
     $this->add(
       'wysiwyg',
@@ -73,7 +75,8 @@ class CRM_Signatures_Form_Signatures extends CRM_Core_Form {
     $this->add(
       'textarea',
       'signature_additional_plain',
-      E::ts('Additional signature (plain text)', array('domain' => 'de.systopia.signatures'))
+      E::ts('Additional signature (plain text)', array('domain' => 'de.systopia.signatures')),
+      ['rows' => '10']
     );
 
     $this->addButtons(array(
@@ -87,10 +90,27 @@ class CRM_Signatures_Form_Signatures extends CRM_Core_Form {
     // Export form elements.
     $this->assign('elementNames', $this->getRenderableElementNames());
     $this->assign('contactID', $contact_id);
-    $this->assign('header', E::ts('You are editing signatures for the contact with the ID <em>%1</em>', array(
-      'domain' => 'de.systopia.signatures',
-      1 => $contact_id,
-    )));
+
+    if ($contact_id == CRM_Core_Session::getLoggedInContactID()) {
+      $header = E::ts('You are editing signatures for yourself (contact ID <em>%1</em>).', array(
+        'domain' => 'de.systopia.signatures',
+        1 => $contact_id,
+      ));
+    }
+    else {
+      $display_name = $contacts = \Civi\Api4\Contact::get(TRUE)
+        ->addSelect('display_name')
+        ->addWhere('id', '=', $contact_id)
+        ->setLimit(1)
+        ->execute()
+        ->first()['display_name'];
+      $header = E::ts('You are editing signatures for the contact <em>%1</em> (contact ID <em>%2</em>).', array(
+        'domain' => 'de.systopia.signatures',
+        1 => $display_name,
+        2 => $contact_id,
+      ));
+    }
+    $this->assign('header', $header);
 
     parent::buildQuickForm();
   }

--- a/templates/CRM/Signatures/Form/Signatures.tpl
+++ b/templates/CRM/Signatures/Form/Signatures.tpl
@@ -1,4 +1,4 @@
-<div class="description">
+<div class="description help">
   {$header}
 </div>
 


### PR DESCRIPTION
Mainly I wanted to offer the user more explicit info about whose signatures are being edited. While I was in there, I also added some other small "improvements" (IMO). 

List of changes:

- **Textarea (plain-text) signature fields:** larger default field size for better readability.
- **Header message:** more explicit info on who's being edited; 'help' styling for visibility.

I hope this is of some value to the project.